### PR TITLE
Serssion 4 homework

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,10 +1,10 @@
 {
     "dev": {
         "contract/valory/erc20/0.1.0": "bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi",
-        "skill/valory/learning_abci/0.1.0": "bafybeih5m372dqrdfy7w6iah4m5qfgf3j5t7ihsgorzyzhax5srm32wmim",
-        "skill/valory/learning_chained_abci/0.1.0": "bafybeihu6uvvdnfntgluhrbxqus5malsit36xqsyxv46wjqsmuodadarpm",
-        "agent/valory/learning_agent/0.1.0": "bafybeiatizepnj42umexk3p5rnop67cdshbgrflvnysaagm3t4xqo74kem",
-        "service/valory/learning_service/0.1.0": "bafybeig34lg3wztyj7ecsbyb6qj7ryf34gnpr2cuoz3akjvgdsh3pejboq"
+        "skill/valory/learning_abci/0.1.0": "bafybeiehp6t26akj6tjhvr2cvahyd3eeas2mv2vatbk66txkdtzgt6f5ce",
+        "skill/valory/learning_chained_abci/0.1.0": "bafybeidy6iwwq7kk3czqmjxbxephozq3ctd6qxwfteua55q7wewncxa7r4",
+        "agent/valory/learning_agent/0.1.0": "bafybeieglrxpql7peorybc76tigtedvctz4uskv4j2jedmgrufj5p2n4ym",
+        "service/valory/learning_service/0.1.0": "bafybeibv4eq45athhbtq2aj3uv32c4cldtdkeoewoxdcubvneokrmnwctu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,10 +1,10 @@
 {
     "dev": {
         "contract/valory/erc20/0.1.0": "bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi",
-        "skill/valory/learning_abci/0.1.0": "bafybeiehp6t26akj6tjhvr2cvahyd3eeas2mv2vatbk66txkdtzgt6f5ce",
-        "skill/valory/learning_chained_abci/0.1.0": "bafybeidy6iwwq7kk3czqmjxbxephozq3ctd6qxwfteua55q7wewncxa7r4",
-        "agent/valory/learning_agent/0.1.0": "bafybeieglrxpql7peorybc76tigtedvctz4uskv4j2jedmgrufj5p2n4ym",
-        "service/valory/learning_service/0.1.0": "bafybeibv4eq45athhbtq2aj3uv32c4cldtdkeoewoxdcubvneokrmnwctu"
+        "skill/valory/learning_abci/0.1.0": "bafybeihjyxcspksysnj53elv2z3yzio3ukfuwe4hmwea7obpmwhoikz4pe",
+        "skill/valory/learning_chained_abci/0.1.0": "bafybeicqea4dxd624hluvrci3fby2acwll3dvsyuercpbg6srwqhtuwvpu",
+        "agent/valory/learning_agent/0.1.0": "bafybeidtndvlvnzdejz6juj4iuokzw5ui65rw2qljpmmxjy66z7ri4fzyi",
+        "service/valory/learning_service/0.1.0": "bafybeie2khdlugxr2gfzpck257k2uplxe3xvmjoricta5k6v5bmhzmdzg4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/learning_agent/aea-config.yaml
+++ b/packages/valory/agents/learning_agent/aea-config.yaml
@@ -32,8 +32,8 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeidz54kvxhbdmpruzguuzzq7bjg4pekjb5amqobkxoy4oqknnobopu
 - valory/abstract_round_abci:0.1.0:bafybeiajjzuh6vf23crp55humonknirvv2f4s3dmdlfzch6tc5ow52pcgm
-- valory/learning_abci:0.1.0:bafybeiehp6t26akj6tjhvr2cvahyd3eeas2mv2vatbk66txkdtzgt6f5ce
-- valory/learning_chained_abci:0.1.0:bafybeidy6iwwq7kk3czqmjxbxephozq3ctd6qxwfteua55q7wewncxa7r4
+- valory/learning_abci:0.1.0:bafybeihjyxcspksysnj53elv2z3yzio3ukfuwe4hmwea7obpmwhoikz4pe
+- valory/learning_chained_abci:0.1.0:bafybeicqea4dxd624hluvrci3fby2acwll3dvsyuercpbg6srwqhtuwvpu
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi

--- a/packages/valory/agents/learning_agent/aea-config.yaml
+++ b/packages/valory/agents/learning_agent/aea-config.yaml
@@ -32,8 +32,8 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeidz54kvxhbdmpruzguuzzq7bjg4pekjb5amqobkxoy4oqknnobopu
 - valory/abstract_round_abci:0.1.0:bafybeiajjzuh6vf23crp55humonknirvv2f4s3dmdlfzch6tc5ow52pcgm
-- valory/learning_abci:0.1.0:bafybeih5m372dqrdfy7w6iah4m5qfgf3j5t7ihsgorzyzhax5srm32wmim
-- valory/learning_chained_abci:0.1.0:bafybeihu6uvvdnfntgluhrbxqus5malsit36xqsyxv46wjqsmuodadarpm
+- valory/learning_abci:0.1.0:bafybeiehp6t26akj6tjhvr2cvahyd3eeas2mv2vatbk66txkdtzgt6f5ce
+- valory/learning_chained_abci:0.1.0:bafybeidy6iwwq7kk3czqmjxbxephozq3ctd6qxwfteua55q7wewncxa7r4
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi

--- a/packages/valory/services/learning_service/service.yaml
+++ b/packages/valory/services/learning_service/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeid42pdrf6qrohedylj4ijrss236ai6geqgf3he44huowiuf7pl464
 fingerprint_ignore_patterns: []
-agent: valory/learning_agent:0.1.0:bafybeieglrxpql7peorybc76tigtedvctz4uskv4j2jedmgrufj5p2n4ym
+agent: valory/learning_agent:0.1.0:bafybeidtndvlvnzdejz6juj4iuokzw5ui65rw2qljpmmxjy66z7ri4fzyi
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/learning_service/service.yaml
+++ b/packages/valory/services/learning_service/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeid42pdrf6qrohedylj4ijrss236ai6geqgf3he44huowiuf7pl464
 fingerprint_ignore_patterns: []
-agent: valory/learning_agent:0.1.0:bafybeiatizepnj42umexk3p5rnop67cdshbgrflvnysaagm3t4xqo74kem
+agent: valory/learning_agent:0.1.0:bafybeieglrxpql7peorybc76tigtedvctz4uskv4j2jedmgrufj5p2n4ym
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/learning_abci/models.py
+++ b/packages/valory/skills/learning_abci/models.py
@@ -59,8 +59,13 @@ class Params(BaseParams):
         # multisend address is used in other skills, so we cannot pop it using _ensure
         self.multisend_address = kwargs.get("multisend_address", "")
 
+        self.coincap_api_key = kwargs.get("coincap_api_key","https://api.coincap.io/v2/rates/ethereum")
+
         super().__init__(*args, **kwargs)
 
 
 class CoingeckoSpecs(ApiSpecs):
     """A model that wraps ApiSpecs for Coingecko API."""
+
+class CoincapSpecs(ApiSpecs):
+    """A model that wraps ApiSpecs for coincap API"""

--- a/packages/valory/skills/learning_abci/payloads.py
+++ b/packages/valory/skills/learning_abci/payloads.py
@@ -48,3 +48,8 @@ class TxPreparationPayload(BaseTxPayload):
 
     tx_submitter: Optional[str] = None
     tx_hash: Optional[str] = None
+
+@dataclass(frozen=True)
+class coincapPayload(BaseTxPayload):
+    """Represent a transaction payload for the coincapRound."""
+    rateUSD: Optional[str]

--- a/packages/valory/skills/learning_abci/skill.yaml
+++ b/packages/valory/skills/learning_abci/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiho3lkochqpmes4f235chq26oggmwnol3vjuvhosleoubbjirbwaq
-  behaviours.py: bafybeiaiy6sh7aqo4zzghnejv55vs43vqtpaipj5cpabx32qdjrqleeeie
+  behaviours.py: bafybeigl4aphbj5u4ordsguxc3orx62vk7jerfabri44ebgofi4i3lypce
   dialogues.py: bafybeifqjbumctlffx2xvpga2kcenezhe47qhksvgmaylyp5ypwqgfar5u
   fsm_specification.yaml: bafybeigbbydxuqephdpatb3fp3sxnvr77bfvvo5hwjimxfpgyl32wupe64
   handlers.py: bafybeigjadr4thz6hfpfx5abezbwnqhbxmachf4efasrn4z2vqhsqgnyvi
-  models.py: bafybeicreffhurci7jzpwvxnlo5z3a2j3vcfgkopg2gtwwxfrncbzk77ra
-  payloads.py: bafybeidc6qqnfvd7qovjatt2i2kbga7pj6epdghlzqxdhzx6b6j6p7ubvm
-  rounds.py: bafybeibcxdou2opzsof4fcnaijfdgzpaaggmucyolhegns3k4zpzvuom2i
+  models.py: bafybeibkssi7x3dkenx7vwuuzdt4plmpfyf5anefesd2uejyvznhfo7i6u
+  payloads.py: bafybeiavrzwyx3j5ebrwjlwoeynommlj34gqe3quj5ich2wmvporvux3c4
+  rounds.py: bafybeiebxe4xos6efwia4eoj37fcjenwkfchmxo7ywikcrpnpb3jwjrtpq
 fingerprint_ignore_patterns: []
 connections: []
 contracts:

--- a/packages/valory/skills/learning_abci/skill.yaml
+++ b/packages/valory/skills/learning_abci/skill.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiho3lkochqpmes4f235chq26oggmwnol3vjuvhosleoubbjirbwaq
-  behaviours.py: bafybeigl4aphbj5u4ordsguxc3orx62vk7jerfabri44ebgofi4i3lypce
+  behaviours.py: bafybeib3xiuguuzzsbdddx6hh7g6enlf6h7owxlf4ddmjquthodpw7xxsy
   dialogues.py: bafybeifqjbumctlffx2xvpga2kcenezhe47qhksvgmaylyp5ypwqgfar5u
   fsm_specification.yaml: bafybeigbbydxuqephdpatb3fp3sxnvr77bfvvo5hwjimxfpgyl32wupe64
   handlers.py: bafybeigjadr4thz6hfpfx5abezbwnqhbxmachf4efasrn4z2vqhsqgnyvi

--- a/packages/valory/skills/learning_chained_abci/skill.yaml
+++ b/packages/valory/skills/learning_chained_abci/skill.yaml
@@ -22,7 +22,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi
-- valory/learning_abci:0.1.0:bafybeiehp6t26akj6tjhvr2cvahyd3eeas2mv2vatbk66txkdtzgt6f5ce
+- valory/learning_abci:0.1.0:bafybeihjyxcspksysnj53elv2z3yzio3ukfuwe4hmwea7obpmwhoikz4pe
 - valory/transaction_settlement_abci:0.1.0:bafybeielv6eivt2z6nforq43xewl2vmpfwpdu2s2vfogobziljnwsclmlm
 behaviours:
   main:

--- a/packages/valory/skills/learning_chained_abci/skill.yaml
+++ b/packages/valory/skills/learning_chained_abci/skill.yaml
@@ -22,7 +22,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi
-- valory/learning_abci:0.1.0:bafybeih5m372dqrdfy7w6iah4m5qfgf3j5t7ihsgorzyzhax5srm32wmim
+- valory/learning_abci:0.1.0:bafybeiehp6t26akj6tjhvr2cvahyd3eeas2mv2vatbk66txkdtzgt6f5ce
 - valory/transaction_settlement_abci:0.1.0:bafybeielv6eivt2z6nforq43xewl2vmpfwpdu2s2vfogobziljnwsclmlm
 behaviours:
   main:


### PR DESCRIPTION
### feat: ETH price from Coincap API

This PR adds functionality to fetch the ETH price from the Coincap API, store it in IPFS, and retrieve it.

The following changes were made:

1. Added get_eth_rate_usd function to coincapBehaviour to fetch the ETH price from Coincap API.  
2. Added store_EthRateUSD function to coincapBehaviour to store the ETH price in IPFS.
3. Added get_EthRateUSD function to coincapBehaviour to retrieve the ETH price from IPFS.  
4. Defined CoincapSpecs in models.py.  
5. Defined coincapPayload in payloads.py.  
6. Defined properties and class for round in rounds.py and added it to rounds flow