### PR TITLE
Add Write Methods to TotalSupplyReader Contract and multisend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ packages/valory/skills/*
 !packages/valory/skills/learning_abci
 !packages/valory/skills/learning_chained_abci
 !packages/valory/contracts/erc20
+!packages/valory/contracts/simple_contract
 
 leak_report
 /Pipfile.lock

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,10 +1,11 @@
 {
     "dev": {
         "contract/valory/erc20/0.1.0": "bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi",
-        "skill/valory/learning_abci/0.1.0": "bafybeibsnezkkf2pffqewrbngspb7bspgcddg7ameghfxjobeyb3nytuaq",
-        "skill/valory/learning_chained_abci/0.1.0": "bafybeieblotrijat6ztytqfysrgze7d3cnkqqoyceglqlh6zqakog2zhba",
-        "agent/valory/learning_agent/0.1.0": "bafybeigcfohdmqj3355spojvz3bfkeuhdqrambrkc3uhb55ew2tuctucrq",
-        "service/valory/learning_service/0.1.0": "bafybeidkxatg6f7hthjcvipekrlpfexamw4uqdtthpfpys2eh4ipev5fku"
+        "contract/valory/simple_contract/0.1.0": "bafybeieikmvwyytviangu3mu7t3373lntzwsh3np2tnoh6wlazhjtfz6xq",
+        "skill/valory/learning_abci/0.1.0": "bafybeiadrtdgnckrke34yhdir5lsgg7vlmlja3xjiwasjxshgv3pmsp4wi",
+        "skill/valory/learning_chained_abci/0.1.0": "bafybeia3em363ge57edgxotkkxaycs73qgxku5hscarr7xdizk6vmew4di",
+        "agent/valory/learning_agent/0.1.0": "bafybeifrgr4sfip4v4nls6epw5r4wm2dtogmavwu6ieapsszx5xfp2zdoq",
+        "service/valory/learning_service/0.1.0": "bafybeihcdbi7jgw7b4b6eexum2if4ey5albvi35d2psohs6ut7wyqopqna"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,11 +1,11 @@
 {
     "dev": {
         "contract/valory/erc20/0.1.0": "bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi",
-        "contract/valory/simple_contract/0.1.0": "bafybeieikmvwyytviangu3mu7t3373lntzwsh3np2tnoh6wlazhjtfz6xq",
-        "skill/valory/learning_abci/0.1.0": "bafybeiadrtdgnckrke34yhdir5lsgg7vlmlja3xjiwasjxshgv3pmsp4wi",
-        "skill/valory/learning_chained_abci/0.1.0": "bafybeia3em363ge57edgxotkkxaycs73qgxku5hscarr7xdizk6vmew4di",
-        "agent/valory/learning_agent/0.1.0": "bafybeifrgr4sfip4v4nls6epw5r4wm2dtogmavwu6ieapsszx5xfp2zdoq",
-        "service/valory/learning_service/0.1.0": "bafybeihcdbi7jgw7b4b6eexum2if4ey5albvi35d2psohs6ut7wyqopqna"
+        "contract/valory/simple_contract/0.1.0": "bafybeiadgqkn5wfi46wznpcz4djrfr7uyhhhrckbfmohb7jfz4dr4hf54e",
+        "skill/valory/learning_abci/0.1.0": "bafybeifvjg7s5qx3uu3cv6hffiyrtareo33bpjqigopeuvtmxcxcli4h5a",
+        "skill/valory/learning_chained_abci/0.1.0": "bafybeiebi2n42hswu6e6pwlamib5rlpb3pqc53tlv7ff2xc5gha4ya24bu",
+        "agent/valory/learning_agent/0.1.0": "bafybeictznb76qpq42x5cy6zs72o67ql76j332dlzwjlrcnskdeqqkxh4u",
+        "service/valory/learning_service/0.1.0": "bafybeidbkxlj3ipk35cxx6g2mgujoh7u5muevp6hkrqdal6lij4rfpvfae"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,10 +1,10 @@
 {
     "dev": {
         "contract/valory/erc20/0.1.0": "bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi",
-        "skill/valory/learning_abci/0.1.0": "bafybeih5m372dqrdfy7w6iah4m5qfgf3j5t7ihsgorzyzhax5srm32wmim",
-        "skill/valory/learning_chained_abci/0.1.0": "bafybeihu6uvvdnfntgluhrbxqus5malsit36xqsyxv46wjqsmuodadarpm",
-        "agent/valory/learning_agent/0.1.0": "bafybeiatizepnj42umexk3p5rnop67cdshbgrflvnysaagm3t4xqo74kem",
-        "service/valory/learning_service/0.1.0": "bafybeig34lg3wztyj7ecsbyb6qj7ryf34gnpr2cuoz3akjvgdsh3pejboq"
+        "skill/valory/learning_abci/0.1.0": "bafybeibsnezkkf2pffqewrbngspb7bspgcddg7ameghfxjobeyb3nytuaq",
+        "skill/valory/learning_chained_abci/0.1.0": "bafybeieblotrijat6ztytqfysrgze7d3cnkqqoyceglqlh6zqakog2zhba",
+        "agent/valory/learning_agent/0.1.0": "bafybeigcfohdmqj3355spojvz3bfkeuhdqrambrkc3uhb55ew2tuctucrq",
+        "service/valory/learning_service/0.1.0": "bafybeidkxatg6f7hthjcvipekrlpfexamw4uqdtthpfpys2eh4ipev5fku"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,10 +2,10 @@
     "dev": {
         "contract/valory/erc20/0.1.0": "bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi",
         "contract/valory/simple_contract/0.1.0": "bafybeiadgqkn5wfi46wznpcz4djrfr7uyhhhrckbfmohb7jfz4dr4hf54e",
-        "skill/valory/learning_abci/0.1.0": "bafybeifvjg7s5qx3uu3cv6hffiyrtareo33bpjqigopeuvtmxcxcli4h5a",
-        "skill/valory/learning_chained_abci/0.1.0": "bafybeiebi2n42hswu6e6pwlamib5rlpb3pqc53tlv7ff2xc5gha4ya24bu",
-        "agent/valory/learning_agent/0.1.0": "bafybeictznb76qpq42x5cy6zs72o67ql76j332dlzwjlrcnskdeqqkxh4u",
-        "service/valory/learning_service/0.1.0": "bafybeidbkxlj3ipk35cxx6g2mgujoh7u5muevp6hkrqdal6lij4rfpvfae"
+        "skill/valory/learning_abci/0.1.0": "bafybeicludmksd5jy6j454fr5bkzddscfoxvmfhwr4a7lgsyghec76omau",
+        "skill/valory/learning_chained_abci/0.1.0": "bafybeiemblicnmy3rn2pvl6bciirr4l44pq4coemnqcn754dpz6ep7p3ui",
+        "agent/valory/learning_agent/0.1.0": "bafybeig3wclpm44su573tpig66h5gzveggmmbug3gs7udo5sbsii2gvhbm",
+        "service/valory/learning_service/0.1.0": "bafybeic4bfhchzmywh45i5fplkssrphrxxluth5iwsxk2dmbniw3r3e2zy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/learning_agent/aea-config.yaml
+++ b/packages/valory/agents/learning_agent/aea-config.yaml
@@ -32,8 +32,8 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeidz54kvxhbdmpruzguuzzq7bjg4pekjb5amqobkxoy4oqknnobopu
 - valory/abstract_round_abci:0.1.0:bafybeiajjzuh6vf23crp55humonknirvv2f4s3dmdlfzch6tc5ow52pcgm
-- valory/learning_abci:0.1.0:bafybeibsnezkkf2pffqewrbngspb7bspgcddg7ameghfxjobeyb3nytuaq
-- valory/learning_chained_abci:0.1.0:bafybeieblotrijat6ztytqfysrgze7d3cnkqqoyceglqlh6zqakog2zhba
+- valory/learning_abci:0.1.0:bafybeiadrtdgnckrke34yhdir5lsgg7vlmlja3xjiwasjxshgv3pmsp4wi
+- valory/learning_chained_abci:0.1.0:bafybeia3em363ge57edgxotkkxaycs73qgxku5hscarr7xdizk6vmew4di
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi

--- a/packages/valory/agents/learning_agent/aea-config.yaml
+++ b/packages/valory/agents/learning_agent/aea-config.yaml
@@ -32,8 +32,8 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeidz54kvxhbdmpruzguuzzq7bjg4pekjb5amqobkxoy4oqknnobopu
 - valory/abstract_round_abci:0.1.0:bafybeiajjzuh6vf23crp55humonknirvv2f4s3dmdlfzch6tc5ow52pcgm
-- valory/learning_abci:0.1.0:bafybeifvjg7s5qx3uu3cv6hffiyrtareo33bpjqigopeuvtmxcxcli4h5a
-- valory/learning_chained_abci:0.1.0:bafybeiebi2n42hswu6e6pwlamib5rlpb3pqc53tlv7ff2xc5gha4ya24bu
+- valory/learning_abci:0.1.0:bafybeicludmksd5jy6j454fr5bkzddscfoxvmfhwr4a7lgsyghec76omau
+- valory/learning_chained_abci:0.1.0:bafybeiemblicnmy3rn2pvl6bciirr4l44pq4coemnqcn754dpz6ep7p3ui
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi

--- a/packages/valory/agents/learning_agent/aea-config.yaml
+++ b/packages/valory/agents/learning_agent/aea-config.yaml
@@ -32,8 +32,8 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeidz54kvxhbdmpruzguuzzq7bjg4pekjb5amqobkxoy4oqknnobopu
 - valory/abstract_round_abci:0.1.0:bafybeiajjzuh6vf23crp55humonknirvv2f4s3dmdlfzch6tc5ow52pcgm
-- valory/learning_abci:0.1.0:bafybeiadrtdgnckrke34yhdir5lsgg7vlmlja3xjiwasjxshgv3pmsp4wi
-- valory/learning_chained_abci:0.1.0:bafybeia3em363ge57edgxotkkxaycs73qgxku5hscarr7xdizk6vmew4di
+- valory/learning_abci:0.1.0:bafybeifvjg7s5qx3uu3cv6hffiyrtareo33bpjqigopeuvtmxcxcli4h5a
+- valory/learning_chained_abci:0.1.0:bafybeiebi2n42hswu6e6pwlamib5rlpb3pqc53tlv7ff2xc5gha4ya24bu
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi

--- a/packages/valory/agents/learning_agent/aea-config.yaml
+++ b/packages/valory/agents/learning_agent/aea-config.yaml
@@ -32,8 +32,8 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeidz54kvxhbdmpruzguuzzq7bjg4pekjb5amqobkxoy4oqknnobopu
 - valory/abstract_round_abci:0.1.0:bafybeiajjzuh6vf23crp55humonknirvv2f4s3dmdlfzch6tc5ow52pcgm
-- valory/learning_abci:0.1.0:bafybeih5m372dqrdfy7w6iah4m5qfgf3j5t7ihsgorzyzhax5srm32wmim
-- valory/learning_chained_abci:0.1.0:bafybeihu6uvvdnfntgluhrbxqus5malsit36xqsyxv46wjqsmuodadarpm
+- valory/learning_abci:0.1.0:bafybeibsnezkkf2pffqewrbngspb7bspgcddg7ameghfxjobeyb3nytuaq
+- valory/learning_chained_abci:0.1.0:bafybeieblotrijat6ztytqfysrgze7d3cnkqqoyceglqlh6zqakog2zhba
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi

--- a/packages/valory/contracts/simple_contract/__init__.py
+++ b/packages/valory/contracts/simple_contract/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2024 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the support resources for an OLAS token contract."""

--- a/packages/valory/contracts/simple_contract/build/simple_contract.json
+++ b/packages/valory/contracts/simple_contract/build/simple_contract.json
@@ -1,0 +1,288 @@
+{
+  "_format": "",
+  "contractName": "",
+  "sourceName": "",
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "guy",
+          "type": "address"
+        },
+        {
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "src",
+          "type": "address"
+        },
+        {
+          "name": "dst",
+          "type": "address"
+        },
+        {
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "withdraw",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "dst",
+          "type": "address"
+        },
+        {
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "deposit",
+      "outputs": [],
+      "payable": true,
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "address"
+        },
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "payable": true,
+      "stateMutability": "payable",
+      "type": "fallback"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "src",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "guy",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "src",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "dst",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "dst",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "Deposit",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "src",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "Withdrawal",
+      "type": "event"
+    }
+  ],
+  "bytecode": "",
+  "deployedBytecode": "",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/packages/valory/contracts/simple_contract/contract.py
+++ b/packages/valory/contracts/simple_contract/contract.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2024 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the class to connect to an ERC20 token contract."""
+
+from typing import Dict, List
+
+from aea.common import JSONLike
+from aea.configurations.base import PublicId
+from aea.contracts.base import Contract
+from aea.crypto.base import LedgerApi
+from aea_ledger_ethereum import EthereumApi
+from eth_typing import BlockIdentifier
+
+
+PUBLIC_ID = PublicId.from_str("valory/simple_contract:0.1.0")
+
+
+class TotalSupplyReader(Contract):
+    """A simple contract to read token balances."""
+
+    contract_id = PUBLIC_ID
+
+    @classmethod
+    def get_total_supply(
+        cls,
+        ledger_api: EthereumApi,
+        contract_address: str,
+    ) -> JSONLike:
+        """Get the total supply of the token."""
+        contract_instance = cls.get_instance(ledger_api, contract_address)
+        total_supply = getattr(contract_instance.functions, "totalSupply")  # noqa
+        token_total_supply = total_supply().call()
+        return dict(total_supply=token_total_supply)

--- a/packages/valory/contracts/simple_contract/contract.py
+++ b/packages/valory/contracts/simple_contract/contract.py
@@ -48,3 +48,17 @@ class TotalSupplyReader(Contract):
         total_supply = getattr(contract_instance.functions, "totalSupply")  # noqa
         token_total_supply = total_supply().call()
         return dict(total_supply=token_total_supply)
+    
+    @classmethod
+    def build_transfer_tx(
+        cls,
+        ledger_api: LedgerApi,
+        contract_address: str,
+        recipient: str,
+        amount: int,
+    ) -> Dict[str, bytes]:
+        """Build an ERC20 transfer."""
+        contract_instance = cls.get_instance(ledger_api, contract_address)
+        checksumed_recipient = ledger_api.api.to_checksum_address(recipient)
+        data = contract_instance.encodeABI("transfer", args=(checksumed_recipient, amount))
+        return {"data": bytes.fromhex(data[2:])}

--- a/packages/valory/contracts/simple_contract/contract.yaml
+++ b/packages/valory/contracts/simple_contract/contract.yaml
@@ -1,0 +1,30 @@
+name: simple_contract
+author: valory
+version: 0.1.0
+type: contract
+description: ERC20 token contract
+license: Apache-2.0
+aea_version: '>=1.0.0, <2.0.0'
+fingerprint:
+  __init__.py: bafybeic5lamzwngtlre5afhne4hjwprbhelkcqqs5zr2qyl3474xgia6jq
+  build/simple_contract.json: bafybeifbyzwztfydi7wjum2faupv7b2wyrnvtjihardsmwqkslkbexr4ni
+  contract.py: bafybeigg4n5mh3ka3rzpw5lqjocjwnsnmwjeuxfz3w4qdowdwn7236uctm
+fingerprint_ignore_patterns: []
+contracts: []
+class_name: TotalSupplyReader
+contract_interface_paths:
+  ethereum: build/simple_contract.json
+dependencies:
+  ecdsa:
+    version: '>=0.15'
+  eth_typing: {}
+  hexbytes: {}
+  open-aea-ledger-ethereum:
+    version: ==1.57.0
+  open-aea-test-autonomy:
+    version: ==0.16.1
+  packaging: {}
+  requests:
+    version: ==2.28.1
+  web3:
+    version: <7,>=6.0.0

--- a/packages/valory/contracts/simple_contract/contract.yaml
+++ b/packages/valory/contracts/simple_contract/contract.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeic5lamzwngtlre5afhne4hjwprbhelkcqqs5zr2qyl3474xgia6jq
   build/simple_contract.json: bafybeifbyzwztfydi7wjum2faupv7b2wyrnvtjihardsmwqkslkbexr4ni
-  contract.py: bafybeigg4n5mh3ka3rzpw5lqjocjwnsnmwjeuxfz3w4qdowdwn7236uctm
+  contract.py: bafybeiajl7uuo7igkcalhv3tgwdix4vbt2hxjc3c4hnmjebozoiva35lku
 fingerprint_ignore_patterns: []
 contracts: []
 class_name: TotalSupplyReader

--- a/packages/valory/services/learning_service/service.yaml
+++ b/packages/valory/services/learning_service/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeid42pdrf6qrohedylj4ijrss236ai6geqgf3he44huowiuf7pl464
 fingerprint_ignore_patterns: []
-agent: valory/learning_agent:0.1.0:bafybeigcfohdmqj3355spojvz3bfkeuhdqrambrkc3uhb55ew2tuctucrq
+agent: valory/learning_agent:0.1.0:bafybeifrgr4sfip4v4nls6epw5r4wm2dtogmavwu6ieapsszx5xfp2zdoq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/learning_service/service.yaml
+++ b/packages/valory/services/learning_service/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeid42pdrf6qrohedylj4ijrss236ai6geqgf3he44huowiuf7pl464
 fingerprint_ignore_patterns: []
-agent: valory/learning_agent:0.1.0:bafybeictznb76qpq42x5cy6zs72o67ql76j332dlzwjlrcnskdeqqkxh4u
+agent: valory/learning_agent:0.1.0:bafybeig3wclpm44su573tpig66h5gzveggmmbug3gs7udo5sbsii2gvhbm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/learning_service/service.yaml
+++ b/packages/valory/services/learning_service/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeid42pdrf6qrohedylj4ijrss236ai6geqgf3he44huowiuf7pl464
 fingerprint_ignore_patterns: []
-agent: valory/learning_agent:0.1.0:bafybeiatizepnj42umexk3p5rnop67cdshbgrflvnysaagm3t4xqo74kem
+agent: valory/learning_agent:0.1.0:bafybeigcfohdmqj3355spojvz3bfkeuhdqrambrkc3uhb55ew2tuctucrq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/learning_service/service.yaml
+++ b/packages/valory/services/learning_service/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeid42pdrf6qrohedylj4ijrss236ai6geqgf3he44huowiuf7pl464
 fingerprint_ignore_patterns: []
-agent: valory/learning_agent:0.1.0:bafybeifrgr4sfip4v4nls6epw5r4wm2dtogmavwu6ieapsszx5xfp2zdoq
+agent: valory/learning_agent:0.1.0:bafybeictznb76qpq42x5cy6zs72o67ql76j332dlzwjlrcnskdeqqkxh4u
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/learning_abci/behaviours.py
+++ b/packages/valory/skills/learning_abci/behaviours.py
@@ -55,6 +55,7 @@ from packages.valory.skills.learning_abci.payloads import (
     NativeTransferPayload,
     TxPreparationPayload,
     TotalSupplyCheckPayload,
+    TokenDepositPayload,
 )
 from packages.valory.skills.learning_abci.rounds import (
     DataPullRound,
@@ -65,6 +66,7 @@ from packages.valory.skills.learning_abci.rounds import (
     SynchronizedData,
     TxPreparationRound,
     TotalSupplyCheckRound,
+    TokenDepositRound,
 )
 from packages.valory.skills.transaction_settlement_abci.payload_tools import (
     hash_payload_to_hex,
@@ -819,6 +821,262 @@ class TxPreparationBehaviour(
         )
 
         self.context.logger.info(f"Safe transaction hash is {safe_tx_hash}")
+
+        return safe_tx_hash
+
+
+class TokenDepositBehaviour(LearningBaseBehaviour):
+    """TokenDepositBehaviour"""
+
+    matching_round: Type[AbstractRound] = TokenDepositRound
+
+    def async_act(self) -> Generator:
+        """Do the act, supporting asynchronous execution."""
+        self.context.logger.info("Entering TokenDepositBehaviour")
+
+        with self.context.benchmark_tool.measure(self.behaviour_id).local():
+            sender = self.context.agent_address
+            # Get timestamp to decide which transaction to make
+            now = int(self.get_sync_timestamp())
+            self.context.logger.info(f"Current timestamp: {now}")
+            last_number = int(str(now)[-1])
+            self.context.logger.info(
+                f"Last Number of timestamp in TokenDeposit Round: {last_number}"
+            )
+            # Decide which transaction to create based on timestamp
+            if last_number % 2 == 0:
+                self.context.logger.info(
+                    "Preparing deposit transaction based on even timestamp"
+                )
+                tx_hash = yield from self.get_deposit_tx_hash()
+            else:
+                self.context.logger.info(
+                    "Preparing multisend transaction based on odd timestamp"
+                )
+                tx_hash = yield from self.get_multisend_safe_tx_hash()
+
+            if tx_hash:
+                self.context.logger.info(
+                    f"Successfully generated transaction hash: {tx_hash}"
+                )
+            else:
+                self.context.logger.error("Failed to generate transaction hash")
+
+            payload = TokenDepositPayload(
+                sender=sender,
+                tx_submitter=self.auto_behaviour_id(),
+                tx_hash=tx_hash,
+            )
+
+        with self.context.benchmark_tool.measure(self.behaviour_id).consensus():
+            yield from self.send_a2a_transaction(payload)
+            yield from self.wait_until_round_end()
+
+        self.context.logger.info("TokenDepositBehaviour completed")
+        self.set_done()
+
+    def get_deposit_tx_hash(self) -> Generator[None, None, Optional[str]]:
+        """Get deposit transaction hash."""
+        self.context.logger.info(
+            f"Building deposit transaction for token at {self.params.olas_token_address}"
+        )
+
+        response_msg = yield from self.get_contract_api_response(
+            performative=ContractApiMessage.Performative.GET_RAW_TRANSACTION,
+            contract_address=self.params.olas_token_address,
+            contract_id=str(TotalSupplyReader.contract_id),
+            contract_callable="build_deposit_tx",
+            chain_id=GNOSIS_CHAIN_ID,
+        )
+
+        if response_msg.performative != ContractApiMessage.Performative.RAW_TRANSACTION:
+            self.context.logger.error(
+                f"Error building deposit tx: got performative {response_msg.performative} "
+                f"instead of {ContractApiMessage.Performative.RAW_TRANSACTION}"
+            )
+            return None
+
+        data = response_msg.raw_transaction.body.get("data")
+        if not data:
+            self.context.logger.error("No deposit tx data received in response")
+            return None
+
+        self.context.logger.info("Successfully built deposit transaction data")
+
+        # Build Safe transaction hash
+        self.context.logger.info("Building Safe transaction hash for deposit")
+        safe_tx_hash = yield from self._build_safe_tx_hash(
+            to_address=self.params.olas_token_address,
+            data=data,
+        )
+
+        if safe_tx_hash:
+            self.context.logger.info(
+                f"Successfully generated Safe transaction hash: {safe_tx_hash}"
+            )
+        else:
+            self.context.logger.error("Failed to generate Safe transaction hash")
+
+        return safe_tx_hash
+
+    def get_native_transfer_data(self) -> Dict:
+        """Get the native transaction data"""
+        data = {VALUE_KEY: 1, TO_ADDRESS_KEY: self.params.transfer_target_address}
+        self.context.logger.info(f"Native transfer data: {data}")
+        return data
+
+    def get_erc20_transfer_data(self) -> Generator[None, None, Optional[str]]:
+        """Get the ERC20 transaction data"""
+        self.context.logger.info("Preparing ERC20 transfer transaction")
+
+        response_msg = yield from self.get_contract_api_response(
+            performative=ContractApiMessage.Performative.GET_RAW_TRANSACTION,
+            contract_address=self.params.olas_token_address,
+            contract_id=str(ERC20.contract_id),
+            contract_callable="build_transfer_tx",
+            recipient=self.params.transfer_target_address,
+            amount=1,
+            chain_id=GNOSIS_CHAIN_ID,
+        )
+
+        if response_msg.performative != ContractApiMessage.Performative.RAW_TRANSACTION:
+            self.context.logger.error(f"Error preparing ERC20 transfer: {response_msg}")
+            return None
+
+        data_bytes: Optional[bytes] = response_msg.raw_transaction.body.get(
+            "data", None
+        )
+
+        if data_bytes is None:
+            self.context.logger.error(
+                f"No data in ERC20 transfer response: {response_msg}"
+            )
+            return None
+
+        data_hex = data_bytes.hex()
+        self.context.logger.info(f"ERC20 transfer data: {data_hex}")
+        return data_hex
+
+    def get_multisend_safe_tx_hash(self) -> Generator[None, None, Optional[str]]:
+        """Get a multisend transaction hash combining native and ERC20 transfers."""
+        self.context.logger.info("Building multisend transaction")
+
+        multi_send_txs = []
+
+        # Add native transfer to multisend
+        native_transfer_data = self.get_native_transfer_data()
+        multi_send_txs.append(
+            {
+                "operation": MultiSendOperation.CALL,
+                "to": self.params.transfer_target_address,
+                "value": native_transfer_data[VALUE_KEY],
+            }
+        )
+        self.context.logger.info("Added native transfer to multisend")
+
+        # Add ERC20 transfer to multisend
+        erc20_transfer_data_hex = yield from self.get_erc20_transfer_data()
+        if erc20_transfer_data_hex is None:
+            self.context.logger.error("Failed to get ERC20 transfer data")
+            return None
+
+        multi_send_txs.append(
+            {
+                "operation": MultiSendOperation.CALL,
+                "to": self.params.olas_token_address,
+                "value": ZERO_VALUE,
+                "data": bytes.fromhex(erc20_transfer_data_hex),
+            }
+        )
+        self.context.logger.info("Added ERC20 transfer to multisend")
+
+        # Build multisend transaction
+        contract_api_msg = yield from self.get_contract_api_response(
+            performative=ContractApiMessage.Performative.GET_RAW_TRANSACTION,
+            contract_address=self.params.multisend_address,
+            contract_id=str(MultiSendContract.contract_id),
+            contract_callable="get_tx_data",
+            multi_send_txs=multi_send_txs,
+            chain_id=GNOSIS_CHAIN_ID,
+        )
+
+        if (
+            contract_api_msg.performative
+            != ContractApiMessage.Performative.RAW_TRANSACTION
+        ):
+            self.context.logger.error(
+                f"Could not get Multisend tx data. Expected: {ContractApiMessage.Performative.RAW_TRANSACTION.value}, "
+                f"Got: {contract_api_msg.performative.value}"
+            )
+            return None
+
+        multisend_data = cast(str, contract_api_msg.raw_transaction.body["data"])[2:]
+        self.context.logger.info(f"Generated multisend data: {multisend_data}")
+
+        # Prepare final Safe transaction
+        safe_tx_hash = yield from self._build_safe_tx_hash(
+            to_address=self.params.multisend_address,
+            value=ZERO_VALUE,
+            data=bytes.fromhex(multisend_data),
+            operation=SafeOperation.DELEGATE_CALL.value,
+        )
+
+        if safe_tx_hash:
+            self.context.logger.info(f"Generated Safe transaction hash: {safe_tx_hash}")
+        else:
+            self.context.logger.error("Failed to generate Safe transaction hash")
+
+        return safe_tx_hash
+
+    def _build_safe_tx_hash(
+        self,
+        to_address: str,
+        value: int = ZERO_VALUE,
+        data: bytes = EMPTY_CALL_DATA,
+        operation: int = SafeOperation.CALL.value,
+    ) -> Generator[None, None, Optional[str]]:
+        """Prepares and returns the safe tx hash for the multisend tx."""
+
+        self.context.logger.info(
+            f"Preparing Safe transaction [Safe: {self.synchronized_data.safe_contract_address}]"
+        )
+
+        response_msg = yield from self.get_contract_api_response(
+            performative=ContractApiMessage.Performative.GET_STATE,
+            contract_address=self.synchronized_data.safe_contract_address,
+            contract_id=str(GnosisSafeContract.contract_id),
+            contract_callable="get_raw_safe_transaction_hash",
+            to_address=to_address,
+            value=value,
+            data=data,
+            safe_tx_gas=SAFE_GAS,
+            chain_id=GNOSIS_CHAIN_ID,
+            operation=operation,
+        )
+
+        if response_msg.performative != ContractApiMessage.Performative.STATE:
+            self.context.logger.error(
+                f"Could not get Safe tx hash. Expected: {ContractApiMessage.Performative.STATE.value}, "
+                f"Got: {response_msg.performative.value}"
+            )
+            return None
+
+        tx_hash: Optional[str] = response_msg.state.body.get("tx_hash", None)
+
+        if tx_hash is None or len(tx_hash) != TX_HASH_LENGTH:
+            self.context.logger.error(f"Invalid Safe tx hash: {tx_hash}")
+            return None
+
+        tx_hash = tx_hash[2:]  # strip the 0x
+
+        safe_tx_hash = hash_payload_to_hex(
+            safe_tx_hash=tx_hash,
+            ether_value=value,
+            safe_tx_gas=SAFE_GAS,
+            to_address=to_address,
+            data=data,
+            operation=operation,
+        )
 
         return safe_tx_hash
 

--- a/packages/valory/skills/learning_abci/behaviours.py
+++ b/packages/valory/skills/learning_abci/behaviours.py
@@ -394,65 +394,61 @@ class NativeTransferBehaviour(LearningBaseBehaviour):
         return safe_tx_hash
 
 
-
-
 class TotalSupplyCheckBehaviour(LearningBaseBehaviour):
-        """TotalSupplyCheckBehaviour"""
+    """TotalSupplyCheckBehaviour"""
 
-        matching_round: Type[AbstractRound] = TotalSupplyCheckRound
+    matching_round: Type[AbstractRound] = TotalSupplyCheckRound
 
-        def async_act(self) -> Generator:
-            """Check the total supply of the token."""
-            with self.context.benchmark_tool.measure(self.behaviour_id).local():
-                sender = self.context.agent_address
+    def async_act(self) -> Generator:
+        """Check the total supply of the token."""
+        with self.context.benchmark_tool.measure(self.behaviour_id).local():
+            sender = self.context.agent_address
 
-                total_supply = yield from self.get_total_supply()
+            total_supply = yield from self.get_total_supply()
 
-                payload = TotalSupplyCheckPayload(sender=sender, total_supply=total_supply)
+            payload = TotalSupplyCheckPayload(sender=sender, total_supply=total_supply)
 
-            with self.context.benchmark_tool.measure(self.behaviour_id).consensus():
-                yield from self.send_a2a_transaction(payload)
-                yield from self.wait_until_round_end()
+        with self.context.benchmark_tool.measure(self.behaviour_id).consensus():
+            yield from self.send_a2a_transaction(payload)
+            yield from self.wait_until_round_end()
 
-            self.set_done()
+        self.set_done()
 
-        def get_total_supply(self) -> Generator[None, None, Optional[float]]:
-            """Get the total supply of the token"""
-            self.context.logger.info(
-                f"Getting total supply for token at address {self.params.olas_token_address}"
+    def get_total_supply(self) -> Generator[None, None, Optional[float]]:
+        """Get the total supply of the token"""
+        self.context.logger.info(
+            f"Getting total supply for token at address {self.params.olas_token_address}"
+        )
+
+        # Use the contract api to interact with the token contract
+        response_msg = yield from self.get_contract_api_response(
+            performative=ContractApiMessage.Performative.GET_RAW_TRANSACTION,  # type: ignore
+            contract_address=self.params.olas_token_address,
+            contract_id=str(TotalSupplyReader.contract_id),
+            contract_callable="get_total_supply",
+            chain_id=GNOSIS_CHAIN_ID,
+        )
+
+        # Check that the response is what we expect
+        if response_msg.performative != ContractApiMessage.Performative.RAW_TRANSACTION:
+            self.context.logger.error(
+                f"Error while retrieving the total supply: {response_msg}"
             )
+            return None
 
-            # Use the contract api to interact with the token contract
-            response_msg = yield from self.get_contract_api_response(
-                performative=ContractApiMessage.Performative.GET_RAW_TRANSACTION,  # type: ignore
-                contract_address=self.params.olas_token_address,
-                contract_id=str(TotalSupplyReader.contract_id),
-                contract_callable="get_total_supply",
-                chain_id=GNOSIS_CHAIN_ID,
+        total_supply = response_msg.raw_transaction.body.get("total_supply", None)
+
+        # Ensure that the total supply is not None
+        if total_supply is None:
+            self.context.logger.error(
+                f"Error while retrieving the total supply: {response_msg}"
             )
+            return None
 
-            # Check that the response is what we expect
-            if response_msg.performative != ContractApiMessage.Performative.RAW_TRANSACTION:
-                self.context.logger.error(
-                    f"Error while retrieving the total supply: {response_msg}"
-                )
-                return None
+        total_supply = total_supply / 10**18  # from wei
 
-            total_supply = response_msg.raw_transaction.body.get("total_supply", None)
-
-            # Ensure that the total supply is not None
-            if total_supply is None:
-                self.context.logger.error(
-                    f"Error while retrieving the total supply: {response_msg}"
-                )
-                return None
-
-            total_supply = total_supply / 10**18  # from wei
-
-            self.context.logger.info(
-                f"Total supply of the token: {total_supply}"
-            )
-            return total_supply
+        self.context.logger.info(f"Total supply of the token: {total_supply}")
+        return total_supply
 
 
 class DecisionMakingBehaviour(
@@ -666,7 +662,7 @@ class TxPreparationBehaviour(
         response_msg = yield from self.get_contract_api_response(
             performative=ContractApiMessage.Performative.GET_RAW_TRANSACTION,  # type: ignore
             contract_address=self.params.olas_token_address,
-            contract_id=str(ERC20.contract_id),
+            contract_id=str(TotalSupplyReader.contract_id),
             contract_callable="build_transfer_tx",
             recipient=self.params.transfer_target_address,
             amount=1,
@@ -837,5 +833,5 @@ class LearningRoundBehaviour(AbstractRoundBehaviour):
         NativeTransferBehaviour,
         DecisionMakingBehaviour,
         TxPreparationBehaviour,
-        TotalSupplyCheckBehaviour, 
+        TotalSupplyCheckBehaviour,
     }

--- a/packages/valory/skills/learning_abci/payloads.py
+++ b/packages/valory/skills/learning_abci/payloads.py
@@ -59,6 +59,14 @@ class NativeTransferPayload(BaseTxPayload):
 
 
 @dataclass(frozen=True)
+class TokenDepositPayload(BaseTxPayload):
+    """Represent a transaction payload for token deposit."""
+
+    tx_submitter: Optional[str]
+    tx_hash: Optional[str]
+
+
+@dataclass(frozen=True)
 class TotalSupplyCheckPayload(BaseTxPayload):
     """Represent a transaction payload for the TxPreparationRound."""
 

--- a/packages/valory/skills/learning_abci/payloads.py
+++ b/packages/valory/skills/learning_abci/payloads.py
@@ -48,3 +48,11 @@ class TxPreparationPayload(BaseTxPayload):
 
     tx_submitter: Optional[str] = None
     tx_hash: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class NativeTransferPayload(BaseTxPayload):
+    """Represent a transaction payload for the TxPreparationRound."""
+
+    tx_submitter: Optional[str]
+    tx_hash: Optional[str]

--- a/packages/valory/skills/learning_abci/payloads.py
+++ b/packages/valory/skills/learning_abci/payloads.py
@@ -56,3 +56,10 @@ class NativeTransferPayload(BaseTxPayload):
 
     tx_submitter: Optional[str]
     tx_hash: Optional[str]
+
+
+@dataclass(frozen=True)
+class TotalSupplyCheckPayload(BaseTxPayload):
+    """Represent a transaction payload for the TxPreparationRound."""
+
+    total_supply: Optional[float]

--- a/packages/valory/skills/learning_abci/rounds.py
+++ b/packages/valory/skills/learning_abci/rounds.py
@@ -37,6 +37,7 @@ from packages.valory.skills.abstract_round_abci.base import (
 from packages.valory.skills.learning_abci.payloads import (
     DataPullPayload,
     DecisionMakingPayload,
+    NativeTransferPayload,
     TxPreparationPayload,
 )
 
@@ -103,6 +104,11 @@ class SynchronizedData(BaseSynchronizedData):
         """Get the round that submitted a tx to transaction_settlement_abci."""
         return str(self.db.get_strict("tx_submitter"))
 
+    @property
+    def participant_to_native_transfer_round(self) -> DeserializedCollection:
+        """Get the participants to the native transfer round."""
+        return self._get_deserialized("participant_to_native_transfer_round")
+
 
 class DataPullRound(CollectSameUntilThresholdRound):
     """DataPullRound"""
@@ -153,6 +159,22 @@ class DecisionMakingRound(CollectSameUntilThresholdRound):
     # Event.DONE, Event.ERROR, Event.TRANSACT, Event.ROUND_TIMEOUT  # this needs to be referenced for static checkers
 
 
+class NativeTransferRound(CollectSameUntilThresholdRound):
+    """NativeTransferRound"""
+
+    payload_class = NativeTransferPayload
+    synchronized_data_class = SynchronizedData
+    done_event = Event.DONE
+    no_majority_event = Event.NO_MAJORITY
+    collection_key = get_name(SynchronizedData.participant_to_native_transfer_round)
+    selection_key = (
+        get_name(SynchronizedData.tx_submitter),
+        get_name(SynchronizedData.most_voted_tx_hash),
+    )
+
+    # Event.ROUND_TIMEOUT  # this needs to be referenced for static checkers
+
+
 class TxPreparationRound(CollectSameUntilThresholdRound):
     """TxPreparationRound"""
 
@@ -200,6 +222,11 @@ class LearningAbciApp(AbciApp[Event]):
         TxPreparationRound: {
             Event.NO_MAJORITY: TxPreparationRound,
             Event.ROUND_TIMEOUT: TxPreparationRound,
+            Event.DONE: NativeTransferRound,
+        },
+        NativeTransferRound: {
+            Event.NO_MAJORITY: NativeTransferRound,
+            Event.ROUND_TIMEOUT: NativeTransferRound,
             Event.DONE: FinishedTxPreparationRound,
         },
         FinishedDecisionMakingRound: {},

--- a/packages/valory/skills/learning_abci/rounds.py
+++ b/packages/valory/skills/learning_abci/rounds.py
@@ -38,6 +38,7 @@ from packages.valory.skills.learning_abci.payloads import (
     DataPullPayload,
     DecisionMakingPayload,
     NativeTransferPayload,
+    TotalSupplyCheckPayload,
     TxPreparationPayload,
 )
 
@@ -109,6 +110,29 @@ class SynchronizedData(BaseSynchronizedData):
         """Get the participants to the native transfer round."""
         return self._get_deserialized("participant_to_native_transfer_round")
 
+    @property
+    def total_supply(self) -> Optional[float]:
+        """Get the total supply."""
+        return self.db.get("total_supply", None)
+
+    @property
+    def participant_to_total_supply_check_round(self) -> DeserializedCollection:
+        """Get the participants to the total supply check round."""
+        return self._get_deserialized("participant_to_total_supply_check_round")
+
+
+class TotalSupplyCheckRound(CollectSameUntilThresholdRound):
+    """TotalSupplyCheckRound"""
+
+    payload_class = TotalSupplyCheckPayload
+    synchronized_data_class = SynchronizedData
+    done_event = Event.DONE
+    no_majority_event = Event.NO_MAJORITY
+    collection_key = get_name(SynchronizedData.participant_to_total_supply_check_round)
+    selection_key = (get_name(SynchronizedData.total_supply),)
+
+    # Event.ROUND_TIMEOUT  # this needs to be referenced for static checkers
+
 
 class DataPullRound(CollectSameUntilThresholdRound):
     """DataPullRound"""
@@ -175,6 +199,22 @@ class NativeTransferRound(CollectSameUntilThresholdRound):
     # Event.ROUND_TIMEOUT  # this needs to be referenced for static checkers
 
 
+class TotalSupplyCheckRound(CollectSameUntilThresholdRound):
+    """TotalSupplyCheckRound"""
+
+    payload_class = TotalSupplyCheckPayload
+    synchronized_data_class = SynchronizedData
+    done_event = Event.DONE
+    no_majority_event = Event.NO_MAJORITY
+    collection_key = get_name(SynchronizedData.participant_to_total_supply_check_round)
+    selection_key = (
+        get_name(SynchronizedData.tx_submitter),
+        get_name(SynchronizedData.most_voted_tx_hash),
+    )
+
+    # Event.ROUND_TIMEOUT  # this needs to be referenced for static checkers
+
+
 class TxPreparationRound(CollectSameUntilThresholdRound):
     """TxPreparationRound"""
 
@@ -210,6 +250,11 @@ class LearningAbciApp(AbciApp[Event]):
         DataPullRound: {
             Event.NO_MAJORITY: DataPullRound,
             Event.ROUND_TIMEOUT: DataPullRound,
+            Event.DONE: TotalSupplyCheckRound,
+        },
+        TotalSupplyCheckRound: {
+            Event.NO_MAJORITY: TotalSupplyCheckRound,
+            Event.ROUND_TIMEOUT: TotalSupplyCheckRound,
             Event.DONE: DecisionMakingRound,
         },
         DecisionMakingRound: {

--- a/packages/valory/skills/learning_abci/rounds.py
+++ b/packages/valory/skills/learning_abci/rounds.py
@@ -40,6 +40,7 @@ from packages.valory.skills.learning_abci.payloads import (
     NativeTransferPayload,
     TotalSupplyCheckPayload,
     TxPreparationPayload,
+    TokenDepositPayload,
 )
 
 
@@ -119,6 +120,11 @@ class SynchronizedData(BaseSynchronizedData):
     def participant_to_total_supply_check_round(self) -> DeserializedCollection:
         """Get the participants to the total supply check round."""
         return self._get_deserialized("participant_to_total_supply_check_round")
+    
+    @property
+    def participant_to_deposit_round(self) -> DeserializedCollection:
+        """Get the participants to deposit round."""
+        return self._get_deserialized("participant_to_deposit_round")
 
 
 class TotalSupplyCheckRound(CollectSameUntilThresholdRound):
@@ -199,6 +205,18 @@ class NativeTransferRound(CollectSameUntilThresholdRound):
     # Event.ROUND_TIMEOUT  # this needs to be referenced for static checkers
 
 
+class TokenDepositRound(CollectSameUntilThresholdRound):
+    """TokenDepositRound"""
+
+    payload_class = TokenDepositPayload
+    synchronized_data_class = SynchronizedData
+    done_event = Event.DONE
+    no_majority_event = Event.NO_MAJORITY
+    collection_key = get_name(SynchronizedData.participant_to_deposit_round)
+    selection_key = (
+        get_name(SynchronizedData.tx_submitter),
+        get_name(SynchronizedData.most_voted_tx_hash),
+    )
 class TotalSupplyCheckRound(CollectSameUntilThresholdRound):
     """TotalSupplyCheckRound"""
 

--- a/packages/valory/skills/learning_abci/skill.yaml
+++ b/packages/valory/skills/learning_abci/skill.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiho3lkochqpmes4f235chq26oggmwnol3vjuvhosleoubbjirbwaq
-  behaviours.py: bafybeiavt5uenuv5rzsawv3ftwxfualdgcr3pnggr3z423bu5vdn4taroy
+  behaviours.py: bafybeia4vhqppspqhtg5ggnyjmtbptd2tdznyzwmsm7qo57vth6u72en4i
   dialogues.py: bafybeifqjbumctlffx2xvpga2kcenezhe47qhksvgmaylyp5ypwqgfar5u
   fsm_specification.yaml: bafybeigbbydxuqephdpatb3fp3sxnvr77bfvvo5hwjimxfpgyl32wupe64
   handlers.py: bafybeigjadr4thz6hfpfx5abezbwnqhbxmachf4efasrn4z2vqhsqgnyvi
@@ -20,7 +20,7 @@ contracts:
 - valory/gnosis_safe:0.1.0:bafybeib375xmvcplw7ageic2np3hq4yqeijrvd5kl7rrdnyvswats6ngmm
 - valory/erc20:0.1.0:bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
-- valory/simple_contract:0.1.0:bafybeieikmvwyytviangu3mu7t3373lntzwsh3np2tnoh6wlazhjtfz6xq
+- valory/simple_contract:0.1.0:bafybeiadgqkn5wfi46wznpcz4djrfr7uyhhhrckbfmohb7jfz4dr4hf54e
 protocols:
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni

--- a/packages/valory/skills/learning_abci/skill.yaml
+++ b/packages/valory/skills/learning_abci/skill.yaml
@@ -7,19 +7,20 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiho3lkochqpmes4f235chq26oggmwnol3vjuvhosleoubbjirbwaq
-  behaviours.py: bafybeig4hd2pqne5b2mvayd6h4njqyvkpdzbkh5y2z6rbitlcyycqirxna
+  behaviours.py: bafybeiavt5uenuv5rzsawv3ftwxfualdgcr3pnggr3z423bu5vdn4taroy
   dialogues.py: bafybeifqjbumctlffx2xvpga2kcenezhe47qhksvgmaylyp5ypwqgfar5u
   fsm_specification.yaml: bafybeigbbydxuqephdpatb3fp3sxnvr77bfvvo5hwjimxfpgyl32wupe64
   handlers.py: bafybeigjadr4thz6hfpfx5abezbwnqhbxmachf4efasrn4z2vqhsqgnyvi
   models.py: bafybeicreffhurci7jzpwvxnlo5z3a2j3vcfgkopg2gtwwxfrncbzk77ra
-  payloads.py: bafybeibu4panheg7yfexayhudln7i2ocydbpyiodm3tu3tt73jyupjl5la
-  rounds.py: bafybeiabv4em3t3wev23sw6kkqhmjckyhkuarzv3g2zvkgd6somdmup45y
+  payloads.py: bafybeihab67xjh2pclzosmw6wg7xtmzte7e4canwnonzxpsnvev2u23wtq
+  rounds.py: bafybeie6kbtsmxtnj5bnymnyu3pyknwwapj24qeipeubtjdbu6nooxdteu
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
 - valory/gnosis_safe:0.1.0:bafybeib375xmvcplw7ageic2np3hq4yqeijrvd5kl7rrdnyvswats6ngmm
 - valory/erc20:0.1.0:bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
+- valory/simple_contract:0.1.0:bafybeieikmvwyytviangu3mu7t3373lntzwsh3np2tnoh6wlazhjtfz6xq
 protocols:
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni

--- a/packages/valory/skills/learning_abci/skill.yaml
+++ b/packages/valory/skills/learning_abci/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiho3lkochqpmes4f235chq26oggmwnol3vjuvhosleoubbjirbwaq
-  behaviours.py: bafybeia4vhqppspqhtg5ggnyjmtbptd2tdznyzwmsm7qo57vth6u72en4i
+  behaviours.py: bafybeianfaxtos67ugyzk5trlzbpwumcg2rynke2guc36rfprr7dduaehi
   dialogues.py: bafybeifqjbumctlffx2xvpga2kcenezhe47qhksvgmaylyp5ypwqgfar5u
   fsm_specification.yaml: bafybeigbbydxuqephdpatb3fp3sxnvr77bfvvo5hwjimxfpgyl32wupe64
   handlers.py: bafybeigjadr4thz6hfpfx5abezbwnqhbxmachf4efasrn4z2vqhsqgnyvi
   models.py: bafybeicreffhurci7jzpwvxnlo5z3a2j3vcfgkopg2gtwwxfrncbzk77ra
-  payloads.py: bafybeihab67xjh2pclzosmw6wg7xtmzte7e4canwnonzxpsnvev2u23wtq
-  rounds.py: bafybeie6kbtsmxtnj5bnymnyu3pyknwwapj24qeipeubtjdbu6nooxdteu
+  payloads.py: bafybeihrlrknfn3a67xxtbvbfskwtjuqbjvlqlxaams4nex7scaeeof6ua
+  rounds.py: bafybeifa4r6tj6xv4wlqiwdqpidwpckktvy3yhc5qocwpqvxgmscjrk7hi
 fingerprint_ignore_patterns: []
 connections: []
 contracts:

--- a/packages/valory/skills/learning_abci/skill.yaml
+++ b/packages/valory/skills/learning_abci/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiho3lkochqpmes4f235chq26oggmwnol3vjuvhosleoubbjirbwaq
-  behaviours.py: bafybeiaiy6sh7aqo4zzghnejv55vs43vqtpaipj5cpabx32qdjrqleeeie
+  behaviours.py: bafybeig4hd2pqne5b2mvayd6h4njqyvkpdzbkh5y2z6rbitlcyycqirxna
   dialogues.py: bafybeifqjbumctlffx2xvpga2kcenezhe47qhksvgmaylyp5ypwqgfar5u
   fsm_specification.yaml: bafybeigbbydxuqephdpatb3fp3sxnvr77bfvvo5hwjimxfpgyl32wupe64
   handlers.py: bafybeigjadr4thz6hfpfx5abezbwnqhbxmachf4efasrn4z2vqhsqgnyvi
   models.py: bafybeicreffhurci7jzpwvxnlo5z3a2j3vcfgkopg2gtwwxfrncbzk77ra
-  payloads.py: bafybeidc6qqnfvd7qovjatt2i2kbga7pj6epdghlzqxdhzx6b6j6p7ubvm
-  rounds.py: bafybeibcxdou2opzsof4fcnaijfdgzpaaggmucyolhegns3k4zpzvuom2i
+  payloads.py: bafybeibu4panheg7yfexayhudln7i2ocydbpyiodm3tu3tt73jyupjl5la
+  rounds.py: bafybeiabv4em3t3wev23sw6kkqhmjckyhkuarzv3g2zvkgd6somdmup45y
 fingerprint_ignore_patterns: []
 connections: []
 contracts:

--- a/packages/valory/skills/learning_chained_abci/skill.yaml
+++ b/packages/valory/skills/learning_chained_abci/skill.yaml
@@ -22,7 +22,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi
-- valory/learning_abci:0.1.0:bafybeiadrtdgnckrke34yhdir5lsgg7vlmlja3xjiwasjxshgv3pmsp4wi
+- valory/learning_abci:0.1.0:bafybeifvjg7s5qx3uu3cv6hffiyrtareo33bpjqigopeuvtmxcxcli4h5a
 - valory/transaction_settlement_abci:0.1.0:bafybeielv6eivt2z6nforq43xewl2vmpfwpdu2s2vfogobziljnwsclmlm
 behaviours:
   main:

--- a/packages/valory/skills/learning_chained_abci/skill.yaml
+++ b/packages/valory/skills/learning_chained_abci/skill.yaml
@@ -22,7 +22,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi
-- valory/learning_abci:0.1.0:bafybeih5m372dqrdfy7w6iah4m5qfgf3j5t7ihsgorzyzhax5srm32wmim
+- valory/learning_abci:0.1.0:bafybeibsnezkkf2pffqewrbngspb7bspgcddg7ameghfxjobeyb3nytuaq
 - valory/transaction_settlement_abci:0.1.0:bafybeielv6eivt2z6nforq43xewl2vmpfwpdu2s2vfogobziljnwsclmlm
 behaviours:
   main:

--- a/packages/valory/skills/learning_chained_abci/skill.yaml
+++ b/packages/valory/skills/learning_chained_abci/skill.yaml
@@ -22,7 +22,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi
-- valory/learning_abci:0.1.0:bafybeifvjg7s5qx3uu3cv6hffiyrtareo33bpjqigopeuvtmxcxcli4h5a
+- valory/learning_abci:0.1.0:bafybeicludmksd5jy6j454fr5bkzddscfoxvmfhwr4a7lgsyghec76omau
 - valory/transaction_settlement_abci:0.1.0:bafybeielv6eivt2z6nforq43xewl2vmpfwpdu2s2vfogobziljnwsclmlm
 behaviours:
   main:

--- a/packages/valory/skills/learning_chained_abci/skill.yaml
+++ b/packages/valory/skills/learning_chained_abci/skill.yaml
@@ -22,7 +22,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi
-- valory/learning_abci:0.1.0:bafybeibsnezkkf2pffqewrbngspb7bspgcddg7ameghfxjobeyb3nytuaq
+- valory/learning_abci:0.1.0:bafybeiadrtdgnckrke34yhdir5lsgg7vlmlja3xjiwasjxshgv3pmsp4wi
 - valory/transaction_settlement_abci:0.1.0:bafybeielv6eivt2z6nforq43xewl2vmpfwpdu2s2vfogobziljnwsclmlm
 behaviours:
   main:


### PR DESCRIPTION
## Description
This PR adds write capabilities to the `TotalSupplyReader` contract and multisend in the `learning_abci` skill by implementing both single deposit and multisend transaction features.

## Changes
### Transaction Logic:
- Timestamp-based decision making between deposit and multisend:
  - Last digit is even: Executes deposit transaction
  - Last digit is odd: Executes multisend transaction (native + ERC20)
- Multisend capabilities:
  - Native token transfer (1 wei)
  - ERC20 token transfer (1 token)
  - Combined into a single atomic transaction

## Testing Steps
- Verify deposit transaction encoding
- Test multisend transaction creation
- Validate timestamp-based decision logic
- Check consensus mechanism
- Test Safe transaction integration
- Verify transaction atomicity in multisend
- Monitor logging output

## Dependencies
- Requires Safe contract integration
- Uses MultiSend contract
- Depends on ERC20 contract interface
- Utilizes TokenReader contract